### PR TITLE
Fix tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,12 +1,12 @@
 module.exports = {
-  // presets: [
-  //   [
-  //     "@babel/preset-env",
-  //     {
-  //       targets: {
-  //         node: "current"
-  //       }
-  //     }
-  //   ]
-  // ]
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        targets: {
+          node: "current"
+        }
+      }
+    ]
+  ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,8 +7,8 @@ module.exports = {
   },
   verbose: true,
   setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
-  testEnvironment: "jest-environment-jsdom-fifteen",
+  testEnvironment: "jest-environment-jsdom-sixteen",
   transformIgnorePatterns: [
-    "node_modules/(?!(svelte-routing)/)"
+    "node_modules/(?!(svelte-routing|precompile-intl-runtime)/)"
   ]
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "rollup -c -w",
     "start": "sirv public",
     "test": "jest src",
-    "test:watch": "npm run jest -- --watch"
+    "test:watch": "npm run test -- --watch"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.10.0",
@@ -16,16 +16,16 @@
     "@testing-library/jest-dom": "^5.11.0",
     "@testing-library/svelte": "^3.0.0",
     "babel-jest": "^25.4.0",
-    "jest": "^25.4.0",
+    "jest": "^25.5.4",
     "jest-environment-jsdom-sixteen": "^1.0.3",
+    "precompile-intl-runtime": "^0.0.5",
     "rollup": "^2.21.0",
     "rollup-plugin-livereload": "^1.3.0",
+    "rollup-plugin-precompile-intl": "^0.0.10",
     "rollup-plugin-svelte": "^5.2.0",
     "rollup-plugin-terser": "^6.1.0",
     "svelte": "^3.24.0",
-    "svelte-jester": "^1.0.6",
-    "precompile-intl-runtime": "^0.0.5",
-    "rollup-plugin-precompile-intl": "^0.0.10"
+    "svelte-jester": "^1.0.6"
   },
   "dependencies": {
     "sirv-cli": "^1.0.0"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,40 +7,41 @@
 	let count3 = 1;
 	let trainers = 0;
 	let friends = 0;
+
 </script>
 
 <main>
 	<h1>Current locale is "{$locale}"</h1>
-	<p data-test-id="plain">{$t("plain")}</p>
-	<p data-test-id="interpolated">
+	<p data-testid="plain">{$t("plain")}</p>
+	<p data-testid="interpolated">
 		{$t("interpolated", { values: { count: count1 } })}
 		<input type="number" bind:value={count1} min="0" max="20">
 	</p>
-	<p data-test-id="interpolated-zero">{$t("interpolated", { values: { count: 0 } })} [zero]</p>
-	<p data-test-id="interpolated-false">{$t("interpolated", { values: { count: false } })} [false]</p>
-	<p data-test-id="interpolated-null">{$t("interpolated", { values: { count: null } })} [null]</p>
-	<p data-test-id="interpolated-undefined">{$t("interpolated", { values: { count: undefined } })} [undefined]</p>
-	<!-- <p data-test-id="time">{$t("time", { values: { now: new Date() } })}</p>
-	<p data-test-id="time-custom-format"">{$t("time-custom-format", { values: { now: new Date() } })}[custom format]</p>
-	<p data-test-id="date">{$t("date", { values: { today: new Date() } })}</p>
-	<p data-test-id="date-custom-format">{$t("date-custom-format", { values: { today: new Date() } })}[custom format]</p>
-	<p data-test-id="number">{$t("number", { values: { n: 1234567 } })}</p>
-	<p data-test-id="percent">{$t("percent", { values: { n: 1234567 } })}</p> -->
-	<p data-test-id="pluralized">
+	<p data-testid="interpolated-zero">{$t("interpolated", { values: { count: 0 } })} [zero]</p>
+	<p data-testid="interpolated-false">{$t("interpolated", { values: { count: false } })} [false]</p>
+	<p data-testid="interpolated-null">{$t("interpolated", { values: { count: null } })} [null]</p>
+	<p data-testid="interpolated-undefined">{$t("interpolated", { values: { count: undefined } })} [undefined]</p>
+	<!-- <p data-testid="time">{$t("time", { values: { now: new Date() } })}</p>
+	<p data-testid="time-custom-format"">{$t("time-custom-format", { values: { now: new Date() } })}[custom format]</p>
+	<p data-testid="date">{$t("date", { values: { today: new Date() } })}</p>
+	<p data-testid="date-custom-format">{$t("date-custom-format", { values: { today: new Date() } })}[custom format]</p>
+	<p data-testid="number">{$t("number", { values: { n: 1234567 } })}</p>
+	<p data-testid="percent">{$t("percent", { values: { n: 1234567 } })}</p> -->
+	<p data-testid="pluralized">
 		{$t("pluralized", { values: { count: count2 } })}
 		<input type="number" bind:value={count2} min="0" max="20">
 	</p>
-	<p data-test-id="pluralized-with-hash">
+	<p data-testid="pluralized-with-hash">
 		{$t("pluralized-with-hash", { values: { count: count3 } })}
 		<input type="number" bind:value={count3} min="0" max="20"> [Interpolation with #]
 	</p>
-	<p data-test-id="selected">
+	<p data-testid="selected">
 		{$t("selected", { values: { gender: selectedGender } })}
 		{#each genders as g}
 			<button type="button" disabled="{selectedGender === g}" on:click="{() => selectedGender = g}">{g}</button>
 		{/each}
 	</p>
-	<p data-test-id="nested-offsets">
+	<p data-testid="nested-offsets">
 		{$t("nested-offsets", { values: { trainers, friends } })}
 		Trainers: <input type="number" bind:value={trainers} min="0" max="20"> | Friends: <input type="number" bind:value={friends} min="0" max="20">
 	</p>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,11 +1,13 @@
-import { cleanup, render } from "@testing-library/svelte";
+import { cleanup, render, findByTestId } from "@testing-library/svelte";
+import './i18n';
 import App from "./App.svelte";
 
 describe("LocationsList", () => {
   afterEach(cleanup);
 
-  test("Displats property internationalized messages", () => {
-    render(App);
-    // assert stuff here
+  test("Displats property internationalized messages", async () => {
+    const {findByTestId} = render(App);
+    const plainElement = await findByTestId('plain')
+    expect(plainElement).toHaveTextContent("Some text without interpolations")
   });
 });


### PR DESCRIPTION
Hi :wave:

I've just setup a first test.
The issue was that `precompile-intl-runtime` is distributed with ES modules which is not supported by node's current runtime. I know there's some progress in newer node versions and `mjs` files won't be needed in a near future, but for now I've just compiled it to make sure it works on older node versions too.

The trick was to update the `transformIgnorePatterns` option in `jest.config.js` to tell jest to run the transformations upon execution on your lib too.

So I think that if you don't want to burden the users of the lib with this compilation setup, you'd need to distribute it in both commonjs and esmodules.

That's what Svelte does for its internals for instance. If I take `node_modules/svelte/internal/index.js`, it's commonjs and there's `node_modules/svelte/internal/index.mjs` which has the esmodules syntax. Rollup and compilers then know which one to import when using `import { x } from "svelte/internal"` by adding a `node_modules/svelte/internal/package.json` file folder that contains two fields:

* `main` field which redirects to the commonjs file
* `module` field which redirects to the esmodules syntax

I've never did it myself though so not sure if this method is enough.

I hope this helps! :slightly_smiling_face: 